### PR TITLE
Fix clearing rdfsbase feature bit in cr4 on exit

### DIFF
--- a/enable_rdfsbase.c
+++ b/enable_rdfsbase.c
@@ -38,7 +38,7 @@ static void set_cr4_fsgsbase(void *_unused)
 static void clear_cr4_fsgsbase(void *_unused)
 {
 #if KERNEL_VERSION(4, 0, 0) <= LINUX_VERSION_CODE
-	cr4_set_bits(CR4_FSGSBASE_MASK);
+	cr4_clear_bits(CR4_FSGSBASE_MASK);
 #else
 	unsigned long cr4_val;
 


### PR DESCRIPTION
When this kernel module is unloaded, the feature bit should be
cleared.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>