### PR TITLE
fix: support kernel >= 5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 obj-m += enable_rdfsbase.o
 
-KERNEL_MAKE := $(MAKE) -C /lib/modules/$(shell uname -r)/build SUBDIRS=$(PWD) 
+KERNEL_MAKE := $(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd)
 
 all:
 	$(KERNEL_MAKE) modules


### PR DESCRIPTION
Fixed according to https://patchwork.kernel.org/patch/10690487/ . Tested on 4.15 and 5.4